### PR TITLE
Moved plugin load back to 'init' action

### DIFF
--- a/drm-plugin.php
+++ b/drm-plugin.php
@@ -29,7 +29,7 @@ if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
  */
 
     // Adds the DRM Plugin after plugins load
-    add_action( 'plugins_loaded', 'DRM_Plugin' );
+    add_action( 'init', 'DRM_Plugin' );
 
     // Creates the instance
     function DRM_Plugin() {


### PR DESCRIPTION
The previous load at plugins_loaded was a very early in the load
process, and ‘init’ brings some advantages to have more of the system
loaded. The disadvantage might be that the theme has already loaded and
might require something from the plugin.